### PR TITLE
Patch to allow running on GPU

### DIFF
--- a/PIL_DAT/dat_model.py
+++ b/PIL_DAT/dat_model.py
@@ -75,6 +75,7 @@ class DATModel(ABC):
 
         def tensor2rgb(tensor: Tensor) -> Image:
             tensor = tensor.squeeze(0).clamp(0, 1).permute(1, 2, 0) * 255
+            tensor = tensor.cpu()
             output = PIL.fromarray(tensor.byte().numpy())
             return output
 


### PR DESCRIPTION
I would like to run the upscaling on GPU. It basically works, by using torch.set_default_device() first, just with one small problem:

```
Traceback (most recent call last):
  File "/opt/ai/run.py", line 28, in <module>
    dat.run(params)
  File "/opt/ai/dat.py", line 70, in run
    output_img = model.upscale(img)
                 ^^^^^^^^^^^^^^^^^^
  File "/opt/ai-venv/lib/python3.11/site-packages/PIL_DAT/dat_model.py", line 103, in upscale
    rgb = tensor2rgb(tensor)
          ^^^^^^^^^^^^^^^^^^
  File "/opt/ai-venv/lib/python3.11/site-packages/PIL_DAT/dat_model.py", line 78, in tensor2rgb
    output = PIL.fromarray(tensor.byte().numpy())
                           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/ai-venv/lib64/python3.11/site-packages/torch/utils/_device.py", line 78, in __torch_function__
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```

With this patch it works.

No support for tiling, though, yet, which becomes more urgent with GPU to not run out of memory (but possible on CPU, too, of course).